### PR TITLE
Fix latexmk build for SAPERE examples

### DIFF
--- a/.github/workflows/build-and-deploy-latex.yml
+++ b/.github/workflows/build-and-deploy-latex.yml
@@ -18,6 +18,10 @@ jobs:
   Setup-Compile-Deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: DanySK/compile-and-publish-all-latex@2.3.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.aux
 *.bbl
 *.blg
+*.fdb_latexmk
+*.fls
 *.log
 *.out
 latex.pdf

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/SAPERE-incarnation-tutorial"]
+	path = ext/SAPERE-incarnation-tutorial
+	url = https://github.com/AlchemistSimulator/SAPERE-incarnation-tutorial.git

--- a/Simulation.tex
+++ b/Simulation.tex
@@ -5,45 +5,6 @@
 
 \title[Simulation]{Stochastic Simulation in Alchemist}
 
-\newcommand\YAMLcolonstyle{\color{red}\mdseries}
-\newcommand\YAMLkeystyle{\color{black}\bfseries}
-\newcommand\YAMLvaluestyle{\color{blue}\mdseries}
-
-\makeatletter
-
-% here is a macro expanding to the name of the language
-% (handy if you decide to change it further down the road)
-\newcommand\language@yaml{yaml}
-
-\expandafter\expandafter\expandafter\lstdefinelanguage
-\expandafter{\language@yaml}
-{
-  keywords={true,false,null,y,n},
-  keywordstyle=\color{darkgray}\bfseries,
-  basicstyle=\scriptsize\YAMLkeystyle\linespread{0.8},
-  sensitive=false,
-  columns=fullflexible,
-  comment=[l]{\#},
-  morecomment=[s]{/*}{*/},
-  commentstyle=\color{purple}\ttfamily,
-  stringstyle=\YAMLvaluestyle\ttfamily,
-  moredelim=[l][\color{orange}]{\&},
-  moredelim=[l][\color{magenta}]{*},
-  moredelim=**[il][\YAMLcolonstyle{:}\YAMLvaluestyle]{:},   % switch to value style at :
-  morestring=[b]',
-  morestring=[b]",
-  literate =    {---}{{\ProcessThreeDashes}}3
-                {>}{{\textcolor{red}\textgreater}}1
-                {|}{{\textcolor{red}\textbar}}1
-                {\ -\ }{{\mdseries\ -\ }}3,
-}
-
-% switch to key style at EOL
-\lst@AddToHook{EveryLine}{\ifx\lst@language\language@yaml\YAMLkeystyle\fi}
-\makeatother
-
-\newcommand\ProcessThreeDashes{\llap{\color{cyan}\mdseries-{-}-}}
-
 \begin{document}
 
 \frame[label=coverpage]{\titlepage}

--- a/Simulation.tex
+++ b/Simulation.tex
@@ -1,7 +1,6 @@
 \documentclass[presentation]{beamer}
 \listfiles
 \usepackage{isac-slides}
-\usepackage{minted}
 \usepackage{listings}
 
 \title[Simulation]{Stochastic Simulation in Alchemist}
@@ -540,12 +539,8 @@ From \cite{SlepoyJPC2008}
 	\end{itemize}
 \end{frame}
 
-\newcommand{\saperesimsize}[2]{
-    \IfFileExists{#1.yml}{}{
-        \immediate\write18{curl https://raw.githubusercontent.com/AlchemistSimulator/SAPERE-incarnation-tutorial/master/src/main/yaml/#1.yml --output #1.yml}
-    }
-    \lstinputlisting[language=yaml,basicstyle=#2,numbers=left,breaklines=true,frame=single]{#1.yml}
-%     \inputminted[fontsize=#2,linenos=true,breaklines=true, frame=single]{yaml}{#1.yml}
+\newcommand{\saperesimsize}[2]{%
+    \lstinputlisting[basicstyle=#2\ttfamily,numbers=left,frame=single]{ext/SAPERE-incarnation-tutorial/src/main/yaml/#1.yml}%
 }
 \newcommand{\saperesim}[1]{\saperesimsize{#1}{\tiny}}
 

--- a/Simulation.tex
+++ b/Simulation.tex
@@ -5,6 +5,25 @@
 
 \title[Simulation]{Stochastic Simulation in Alchemist}
 
+\lstdefinelanguage{yaml}{
+  keywords={true,false,null,y,n},
+  keywordstyle=\color{darkgray}\bfseries,
+  basicstyle=\scriptsize\ttfamily,
+  sensitive=false,
+  comment=[l]{\#},
+  commentstyle=\color{purple}\ttfamily,
+  morestring=[b]',
+  morestring=[b]",
+  stringstyle=\color{blue}\ttfamily,
+  moredelim=[l][\color{orange}]{\&},
+  moredelim=[l][\color{magenta}]{*},
+  moredelim=**[il][\color{red}]{:},
+  literate=
+    {---}{{\textcolor{cyan}{---}}}3
+    {>}{{\textcolor{red}{>}}}1
+    {|}{{\textcolor{red}{|}}}1,
+}
+
 \begin{document}
 
 \frame[label=coverpage]{\titlepage}
@@ -501,7 +520,7 @@ From \cite{SlepoyJPC2008}
 \end{frame}
 
 \newcommand{\saperesimsize}[2]{%
-    \lstinputlisting[basicstyle=#2\ttfamily,numbers=left,frame=single]{ext/SAPERE-incarnation-tutorial/src/main/yaml/#1.yml}%
+    \lstinputlisting[language=yaml,basicstyle=#2\ttfamily,numbers=left,frame=single]{ext/SAPERE-incarnation-tutorial/src/main/yaml/#1.yml}%
 }
 \newcommand{\saperesim}[1]{\saperesimsize{#1}{\tiny}}
 


### PR DESCRIPTION
## Summary
- replace runtime YAML downloads with a checked-out SAPERE tutorial submodule
- point the slide deck at the submodule files and drop the unused minted package
- ignore latexmk auxiliary files that this build generates

## Verification
- latexmk -pdf -file-line-error -interaction=nonstopmode -synctex=1 -output-format=pdf Simulation.tex
